### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/at_protocol.py
+++ b/examples/at_protocol.py
@@ -91,7 +91,7 @@ class ATProtocol(serial.threaded.LineReader):
                     else:
                         lines.append(line)
                 except queue.Empty:
-                    raise ATException('AT command timeout (%r)' % (command,))
+                    raise ATException('AT command timeout ({0!r})'.format(command))
 
 
 # test
@@ -123,16 +123,16 @@ if __name__ == '__main__':
             """Handle events and command responses starting with '+...'"""
             if event.startswith('+RRBDRES') and self._awaiting_response_for.startswith('AT+JRBD'):
                 rev = event[9:9+12]
-                mac = ':'.join('%02X' % ord(x) for x in rev.decode('hex')[::-1])
+                mac = ':'.join('{0:02X}'.format(ord(x)) for x in rev.decode('hex')[::-1])
                 self.event_responses.put(mac)
             else:
-                logging.warning('unhandled event: %r' % event)
+                logging.warning('unhandled event: {0!r}'.format(event))
 
         def command_with_event_response(self, command):
             """Send a command that responds with '+...' line"""
             with self.lock:  # ensure that just one thread is sending commands at once
                 self._awaiting_response_for = command
-                self.transport.write(b'%s\r\n' % (command.encode(self.ENCODING, self.UNICODE_HANDLING),))
+                self.transport.write(b'{0!s}\r\n'.format(command.encode(self.ENCODING, self.UNICODE_HANDLING)))
                 response = self.event_responses.get()
                 self._awaiting_response_for = None
                 return response

--- a/examples/port_publisher.py
+++ b/examples/port_publisher.py
@@ -86,7 +86,7 @@ class ZeroconfService:
             self.group = None
 
     def __str__(self):
-        return "%r @ %s:%s (%s)" % (self.name, self.host, self.port, self.stype)
+        return "{0!r} @ {1!s}:{2!s} ({3!s})".format(self.name, self.host, self.port, self.stype)
 
 
 class Forwarder(ZeroconfService):
@@ -154,7 +154,7 @@ class Forwarder(ZeroconfService):
             self.handle_server_error()
             #~ raise
         if self.log is not None:
-            self.log.info("%s: Waiting for connection on %s..." % (self.device, self.network_port))
+            self.log.info("{0!s}: Waiting for connection on {1!s}...".format(self.device, self.network_port))
 
         # zeroconfig
         self.publish()
@@ -165,7 +165,7 @@ class Forwarder(ZeroconfService):
     def close(self):
         """Close all resources and unpublish service"""
         if self.log is not None:
-            self.log.info("%s: closing..." % (self.device, ))
+            self.log.info("{0!s}: closing...".format(self.device ))
         self.alive = False
         self.unpublish()
         if self.server_socket:
@@ -291,7 +291,7 @@ class Forwarder(ZeroconfService):
             self.socket.setblocking(0)
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             if self.log is not None:
-                self.log.warning('%s: Connected by %s:%s' % (self.device, addr[0], addr[1]))
+                self.log.warning('{0!s}: Connected by {1!s}:{2!s}'.format(self.device, addr[0], addr[1]))
             self.serial.rts = True
             self.serial.dtr = True
             if self.log is not None:
@@ -302,7 +302,7 @@ class Forwarder(ZeroconfService):
             # reject connection if there is already one
             connection.close()
             if self.log is not None:
-                self.log.warning('%s: Rejecting connect from %s:%s' % (self.device, addr[0], addr[1]))
+                self.log.warning('{0!s}: Rejecting connect from {1!s}:{2!s}'.format(self.device, addr[0], addr[1]))
 
     def handle_server_error(self):
         """Socket server fails"""
@@ -326,7 +326,7 @@ class Forwarder(ZeroconfService):
                 self.socket.close()
                 self.socket = None
                 if self.log is not None:
-                    self.log.warning('%s: Disconnected' % self.device)
+                    self.log.warning('{0!s}: Disconnected'.format(self.device))
 
 
 def test():
@@ -450,7 +450,7 @@ terminated, it waits for the next connect.
                 # exit first parent
                 sys.exit(0)
         except OSError as e:
-            log.critical("fork #1 failed: %d (%s)\n" % (e.errno, e.strerror))
+            log.critical("fork #1 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
             sys.exit(1)
 
         # decouple from parent environment
@@ -464,10 +464,10 @@ terminated, it waits for the next connect.
             if pid > 0:
                 # exit from second parent, save eventual PID before
                 if args.pidfile is not None:
-                    open(args.pidfile, 'w').write("%d" % pid)
+                    open(args.pidfile, 'w').write("{0:d}".format(pid))
                 sys.exit(0)
         except OSError as e:
-            log.critical("fork #2 failed: %d (%s)\n" % (e.errno, e.strerror))
+            log.critical("fork #2 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
             sys.exit(1)
 
         if args.logfile is None:
@@ -511,7 +511,7 @@ terminated, it waits for the next connect.
         except KeyError:
             pass
         else:
-            log.info("unpublish: %s" % (forwarder))
+            log.info("unpublish: {0!s}".format((forwarder)))
 
     alive = True
     next_check = 0
@@ -525,7 +525,7 @@ terminated, it waits for the next connect.
                 connected = [d for d, p, i in serial.tools.list_ports.grep(args.ports_regex)]
                 # Handle devices that are published, but no longer connected
                 for device in set(published).difference(connected):
-                    log.info("unpublish: %s" % (published[device]))
+                    log.info("unpublish: {0!s}".format((published[device])))
                     unpublish(published[device])
                 # Handle devices that are connected but not yet published
                 for device in sorted(set(connected).difference(published)):
@@ -536,11 +536,11 @@ terminated, it waits for the next connect.
                         port += 1
                     published[device] = Forwarder(
                             device,
-                            "%s on %s" % (device, hostname),
+                            "{0!s} on {1!s}".format(device, hostname),
                             port,
                             on_close=unpublish,
                             log=log)
-                    log.warning("publish: %s" % (published[device]))
+                    log.warning("publish: {0!s}".format((published[device])))
                     published[device].open()
 
             # select_start = time.time()

--- a/examples/rfc2217_server.py
+++ b/examples/rfc2217_server.py
@@ -59,7 +59,7 @@ class Redirector(object):
                     # escape outgoing data when needed (Telnet IAC (0xff) character)
                     self.write(serial.to_bytes(self.rfc2217.escape(data)))
             except socket.error as msg:
-                self.log.error('%s' % (msg,))
+                self.log.error('{0!s}'.format(msg))
                 # probably got disconnected
                 break
         self.alive = False
@@ -79,7 +79,7 @@ class Redirector(object):
                     break
                 self.serial.write(serial.to_bytes(self.rfc2217.filter(data)))
             except socket.error as msg:
-                self.log.error('%s' % (msg,))
+                self.log.error('{0!s}'.format(msg))
                 # probably got disconnected
                 break
         self.stop()

--- a/examples/tcp_serial_redirect.py
+++ b/examples/tcp_serial_redirect.py
@@ -146,7 +146,7 @@ it waits for the next connect.
                             break
                         ser.write(data)                 # get a bunch of bytes and send them
                     except socket.error as msg:
-                        sys.stderr.write('ERROR: %s\n' % msg)
+                        sys.stderr.write('ERROR: {0!s}\n'.format(msg))
                         # probably got disconnected
                         break
             except socket.error as msg:

--- a/examples/wxSerialConfigDialog.py
+++ b/examples/wxSerialConfigDialog.py
@@ -99,7 +99,7 @@ class SerialConfigDialog(wx.Dialog):
         self.choice_port.Clear()
         self.ports = []
         for n, (portname, desc, hwid) in enumerate(sorted(serial.tools.list_ports.comports())):
-            self.choice_port.Append('%s - %s' % (portname, desc))
+            self.choice_port.Append('{0!s} - {1!s}'.format(portname, desc))
             self.ports.append(portname)
             if self.serial.name == portname:
                 preferred_index = n
@@ -115,7 +115,7 @@ class SerialConfigDialog(wx.Dialog):
             if preferred_index is not None:
                 self.combo_box_baudrate.SetSelection(preferred_index)
             else:
-                self.combo_box_baudrate.SetValue(u'%d' % (self.serial.baudrate,))
+                self.combo_box_baudrate.SetValue(u'{0:d}'.format(self.serial.baudrate))
         if self.show & SHOW_FORMAT:
             # fill in data bits and select current setting
             self.choice_databits.Clear()

--- a/examples/wxTerminal.py
+++ b/examples/wxTerminal.py
@@ -274,14 +274,14 @@ class TerminalFrame(wx.Frame):
                         dlg.ShowModal()
                 else:
                     self.StartThread()
-                    self.SetTitle("Serial Terminal on %s [%s,%s,%s,%s%s%s]" % (
+                    self.SetTitle("Serial Terminal on {0!s} [{1!s},{2!s},{3!s},{4!s}{5!s}{6!s}]".format(
                             self.serial.portstr,
                             self.serial.baudrate,
                             self.serial.bytesize,
                             self.serial.parity,
                             self.serial.stopbits,
                             ' RTS/CTS' if self.serial.rtscts else '',
-                            ' Xon/Xoff' if self.serial.xonxoff else '',
+                            ' Xon/Xoff' if self.serial.xonxoff else ''
                             ))
                     ok = True
             else:

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -27,7 +27,7 @@ else:
     elif os.name == 'java':
         from serial.serialjava import Serial
     else:
-        raise ImportError("Sorry: no implementation for your platform ('%s') available" % (os.name,))
+        raise ImportError("Sorry: no implementation for your platform ('{0!s}') available".format(os.name))
 
 
 protocol_handler_packages = [
@@ -63,7 +63,7 @@ def serial_for_url(url, *args, **kwargs):
         # if it is an URL, try to import the handler module from the list of possible packages
         if '://' in url_lowercase:
             protocol = url_lowercase.split('://', 1)[0]
-            module_name = '.protocol_%s' % (protocol,)
+            module_name = '.protocol_{0!s}'.format(protocol)
             for package_name in protocol_handler_packages:
                 try:
                     importlib.import_module(package_name)
@@ -77,7 +77,7 @@ def serial_for_url(url, *args, **kwargs):
                         klass = handler_module.Serial
                     break
             else:
-                raise ValueError('invalid URL, protocol %r not known' % (protocol,))
+                raise ValueError('invalid URL, protocol {0!r} not known'.format(protocol))
     # instantiate and open when desired
     instance = klass(None, *args, **kwargs)
     instance.port = url

--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -258,7 +258,7 @@ class TelnetOption(object):
 
     def __repr__(self):
         """String for debug outputs"""
-        return "%s:%s(%s)" % (self.name, self.active, self.state)
+        return "{0!s}:{1!s}({2!s})".format(self.name, self.active, self.state)
 
     def process_incoming(self, command):
         """\
@@ -282,7 +282,7 @@ class TelnetOption(object):
             elif self.state is REALLY_INACTIVE:
                 self.connection.telnetSendOption(self.send_no, self.option)
             else:
-                raise ValueError('option in illegal state %r' % self)
+                raise ValueError('option in illegal state {0!r}'.format(self))
         elif command == self.ack_no:
             if self.state is REQUESTED:
                 self.state = INACTIVE
@@ -296,7 +296,7 @@ class TelnetOption(object):
             elif self.state is REALLY_INACTIVE:
                 pass
             else:
-                raise ValueError('option in illegal state %r' % self)
+                raise ValueError('option in illegal state {0!r}'.format(self))
 
 
 class TelnetSubnegotiation(object):
@@ -317,7 +317,7 @@ class TelnetSubnegotiation(object):
 
     def __repr__(self):
         """String for debug outputs."""
-        return "%s:%s" % (self.name, self.state)
+        return "{0!s}:{1!s}".format(self.name, self.state)
 
     def set(self, value):
         """\
@@ -329,7 +329,7 @@ class TelnetSubnegotiation(object):
         self.state = REQUESTED
         self.connection.rfc2217SendSubnegotiation(self.option, self.value)
         if self.connection.logger:
-            self.connection.logger.debug("SB Requesting %s -> %r" % (self.name, self.value))
+            self.connection.logger.debug("SB Requesting {0!s} -> {1!r}".format(self.name, self.value))
 
     def isReady(self):
         """\
@@ -337,7 +337,7 @@ class TelnetSubnegotiation(object):
         the change, raise a ValueError.
         """
         if self.state == REALLY_INACTIVE:
-            raise ValueError("remote rejected value for option %r" % (self.name))
+            raise ValueError("remote rejected value for option {0!r}".format((self.name)))
         return self.state == ACTIVE
     # add property to have a similar interface as TelnetOption
     active = property(isReady)
@@ -354,7 +354,7 @@ class TelnetSubnegotiation(object):
             if self.isReady():
                 break
         else:
-            raise SerialException("timeout while waiting for option %r" % (self.name))
+            raise SerialException("timeout while waiting for option {0!r}".format((self.name)))
 
     def checkAnswer(self, suboption):
         """\
@@ -367,7 +367,7 @@ class TelnetSubnegotiation(object):
             # error propagation done in isReady
             self.state = REALLY_INACTIVE
         if self.connection.logger:
-            self.connection.logger.debug("SB Answer %s -> %r -> %s" % (self.name, suboption, self.state))
+            self.connection.logger.debug("SB Answer {0!s} -> {1!r} -> {2!s}".format(self.name, suboption, self.state))
 
 
 class Serial(SerialBase):
@@ -399,7 +399,7 @@ class Serial(SerialBase):
             self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except Exception as msg:
             self._socket = None
-            raise SerialException("Could not open port %s: %s" % (self.portstr, msg))
+            raise SerialException("Could not open port {0!s}: {1!s}".format(self.portstr, msg))
 
         self._socket.settimeout(5)  # XXX good value?
 
@@ -447,7 +447,7 @@ class Serial(SerialBase):
         self.is_open = True
         self._thread = threading.Thread(target=self._telnetReadLoop)
         self._thread.setDaemon(True)
-        self._thread.setName('pySerial RFC 2217 reader thread for %s' % (self._port,))
+        self._thread.setName('pySerial RFC 2217 reader thread for {0!s}'.format(self._port))
         self._thread.start()
 
         try:    # must clean-up if open fails
@@ -462,9 +462,9 @@ class Serial(SerialBase):
                 if sum(o.active for o in mandadory_options) == sum(o.state != INACTIVE for o in mandadory_options):
                     break
             else:
-                raise SerialException("Remote does not seem to support RFC2217 or BINARY mode %r" % mandadory_options)
+                raise SerialException("Remote does not seem to support RFC2217 or BINARY mode {0!r}".format(mandadory_options))
             if self.logger:
-                self.logger.info("Negotiated options: %s" % self._telnet_options)
+                self.logger.info("Negotiated options: {0!s}".format(self._telnet_options))
 
             # fine, go on, set RFC 2271 specific things
             self._reconfigure_port()
@@ -494,7 +494,7 @@ class Serial(SerialBase):
         # Setup the connection
         # to get good performance, all parameter changes are sent first...
         if not 0 < self._baudrate < 2**32:
-            raise ValueError("invalid baudrate: %r" % (self._baudrate))
+            raise ValueError("invalid baudrate: {0!r}".format((self._baudrate)))
         self._rfc2217_port_settings['baudrate'].set(struct.pack(b'!I', self._baudrate))
         self._rfc2217_port_settings['datasize'].set(struct.pack(b'!B', self._bytesize))
         self._rfc2217_port_settings['parity'].set(struct.pack(b'!B', RFC2217_PARITY_MAP[self._parity]))
@@ -503,16 +503,16 @@ class Serial(SerialBase):
         # and now wait until parameters are active
         items = self._rfc2217_port_settings.values()
         if self.logger:
-            self.logger.debug("Negotiating settings: %s" % (items,))
+            self.logger.debug("Negotiating settings: {0!s}".format(items))
         timeout_time = time.time() + self._network_timeout
         while time.time() < timeout_time:
             time.sleep(0.05)    # prevent 100% CPU load
             if sum(o.active for o in items) == len(items):
                 break
         else:
-            raise SerialException("Remote does not accept parameter change (RFC2217): %r" % items)
+            raise SerialException("Remote does not accept parameter change (RFC2217): {0!r}".format(items))
         if self.logger:
-            self.logger.info("Negotiated settings: %s" % (items,))
+            self.logger.info("Negotiated settings: {0!s}".format(items))
 
         if self._rtscts and self._xonxoff:
             raise ValueError('xonxoff and rtscts together are not supported')
@@ -544,7 +544,7 @@ class Serial(SerialBase):
         """extract host and port from an URL string"""
         parts = urlparse.urlsplit(url)
         if parts.scheme != "rfc2217":
-            raise SerialException('expected a string in the form "rfc2217://<host>:<port>[?option[&option...]]": not starting with rfc2217:// (%r)' % (parts.scheme,))
+            raise SerialException('expected a string in the form "rfc2217://<host>:<port>[?option[&option...]]": not starting with rfc2217:// ({0!r})'.format(parts.scheme))
         try:
             # process options now, directly altering self
             for option, values in urlparse.parse_qs(parts.query, True).items():
@@ -560,13 +560,13 @@ class Serial(SerialBase):
                 elif option == 'timeout':
                     self._network_timeout = float(values[0])
                 else:
-                    raise ValueError('unknown option: %r' % (option,))
+                    raise ValueError('unknown option: {0!r}'.format(option))
             # get host and port
             host, port = parts.hostname, parts.port
             if not 0 <= port < 65536:
                 raise ValueError("port not in range 0...65535")
         except ValueError as e:
-            raise SerialException('expected a string in the form "rfc2217://<host>:<port>[?option[&option...]]": %s' % e)
+            raise SerialException('expected a string in the form "rfc2217://<host>:<port>[?option[&option...]]": {0!s}'.format(e))
         return (host, port)
 
     #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
@@ -608,7 +608,7 @@ class Serial(SerialBase):
             try:
                 self._socket.sendall(to_bytes(data).replace(IAC, IAC_DOUBLED))
             except socket.error as e:
-                raise SerialException("connection failed (socket error): %s" % (e,))
+                raise SerialException("connection failed (socket error): {0!s}".format(e))
         return len(data)
 
     def reset_input_buffer(self):
@@ -637,7 +637,7 @@ class Serial(SerialBase):
         if not self.is_open:
             raise portNotOpenError
         if self.logger:
-            self.logger.info('set BREAK to %s' % ('active' if self._break_state else 'inactive'))
+            self.logger.info('set BREAK to {0!s}'.format(('active' if self._break_state else 'inactive')))
         if self._break_state:
             self.rfc2217SetControl(SET_CONTROL_BREAK_ON)
         else:
@@ -648,7 +648,7 @@ class Serial(SerialBase):
         if not self.is_open:
             raise portNotOpenError
         if self.logger:
-            self.logger.info('set RTS to %s' % ('active' if self._rts_state else 'inactive'))
+            self.logger.info('set RTS to {0!s}'.format(('active' if self._rts_state else 'inactive')))
         if self._rts_state:
             self.rfc2217SetControl(SET_CONTROL_RTS_ON)
         else:
@@ -659,7 +659,7 @@ class Serial(SerialBase):
         if not self.is_open:
             raise portNotOpenError
         if self.logger:
-            self.logger.info('set DTR to %s' % ('active' if self._dtr_state else 'inactive'))
+            self.logger.info('set DTR to {0!s}'.format(('active' if self._dtr_state else 'inactive')))
         if self._dtr_state:
             self.rfc2217SetControl(SET_CONTROL_DTR_ON)
         else:
@@ -713,7 +713,7 @@ class Serial(SerialBase):
                 except socket.error as e:
                     # connection fails -> terminate loop
                     if self.logger:
-                        self.logger.debug("socket error in reader thread: %s" % (e,))
+                        self.logger.debug("socket error in reader thread: {0!s}".format(e))
                     break
                 if not data:
                     break  # lost connection
@@ -769,7 +769,7 @@ class Serial(SerialBase):
         """Process commands other than DO, DONT, WILL, WONT."""
         # Currently none. RFC2217 only uses negotiation and subnegotiation.
         if self.logger:
-            self.logger.warning("ignoring Telnet command: %r" % (command,))
+            self.logger.warning("ignoring Telnet command: {0!r}".format(command))
 
     def _telnetNegotiateOption(self, command, option):
         """Process incoming DO, DONT, WILL, WONT."""
@@ -788,7 +788,7 @@ class Serial(SerialBase):
             if command == WILL or command == DO:
                 self.telnetSendOption((DONT if command == WILL else WONT), option)
                 if self.logger:
-                    self.logger.warning("rejected Telnet option: %r" % (option,))
+                    self.logger.warning("rejected Telnet option: {0!r}".format(option))
 
     def _telnetProcessSubnegotiation(self, suboption):
         """Process subnegotiation, the data between IAC SB and IAC SE."""
@@ -796,11 +796,11 @@ class Serial(SerialBase):
             if suboption[1:2] == SERVER_NOTIFY_LINESTATE and len(suboption) >= 3:
                 self._linestate = ord(suboption[2:3])  # ensure it is a number
                 if self.logger:
-                    self.logger.info("NOTIFY_LINESTATE: %s" % self._linestate)
+                    self.logger.info("NOTIFY_LINESTATE: {0!s}".format(self._linestate))
             elif suboption[1:2] == SERVER_NOTIFY_MODEMSTATE and len(suboption) >= 3:
                 self._modemstate = ord(suboption[2:3])  # ensure it is a number
                 if self.logger:
-                    self.logger.info("NOTIFY_MODEMSTATE: %s" % self._modemstate)
+                    self.logger.info("NOTIFY_MODEMSTATE: {0!s}".format(self._modemstate))
                 # update time when we think that a poll would make sense
                 self._modemstate_expires = time.time() + 0.3
             elif suboption[1:2] == FLOWCONTROL_SUSPEND:
@@ -815,10 +815,10 @@ class Serial(SerialBase):
                         break
                 else:
                     if self.logger:
-                        self.logger.warning("ignoring COM_PORT_OPTION: %r" % (suboption,))
+                        self.logger.warning("ignoring COM_PORT_OPTION: {0!r}".format(suboption))
         else:
             if self.logger:
-                self.logger.warning("ignoring subnegotiation: %r" % (suboption,))
+                self.logger.warning("ignoring subnegotiation: {0!r}".format(suboption))
 
     # - outgoing telnet commands and options
 
@@ -997,7 +997,7 @@ class PortManager(object):
                         SERVER_NOTIFY_MODEMSTATE,
                         to_bytes([modemstate & self.modemstate_mask]))
                 if self.logger:
-                    self.logger.info("NOTIFY_MODEMSTATE: %s" % (modemstate,))
+                    self.logger.info("NOTIFY_MODEMSTATE: {0!s}".format(modemstate))
             # save last state, but forget about deltas.
             # otherwise it would also notify about changing deltas which is
             # probably not very useful
@@ -1085,7 +1085,7 @@ class PortManager(object):
         """Process commands other than DO, DONT, WILL, WONT."""
         # Currently none. RFC2217 only uses negotiation and subnegotiation.
         if self.logger:
-            self.logger.warning("ignoring Telnet command: %r" % (command,))
+            self.logger.warning("ignoring Telnet command: {0!r}".format(command))
 
     def _telnetNegotiateOption(self, command, option):
         """Process incoming DO, DONT, WILL, WONT."""
@@ -1104,13 +1104,13 @@ class PortManager(object):
             if command == WILL or command == DO:
                 self.telnetSendOption((DONT if command == WILL else WONT), option)
                 if self.logger:
-                    self.logger.warning("rejected Telnet option: %r" % (option,))
+                    self.logger.warning("rejected Telnet option: {0!r}".format(option))
 
     def _telnetProcessSubnegotiation(self, suboption):
         """Process subnegotiation, the data between IAC SB and IAC SE."""
         if suboption[0:1] == COM_PORT_OPTION:
             if self.logger:
-                self.logger.debug('received COM_PORT_OPTION: %r' % (suboption,))
+                self.logger.debug('received COM_PORT_OPTION: {0!r}'.format(suboption))
             if suboption[1:2] == SET_BAUDRATE:
                 backup = self.serial.baudrate
                 try:
@@ -1119,11 +1119,11 @@ class PortManager(object):
                         self.serial.baudrate = baudrate
                 except ValueError as e:
                     if self.logger:
-                        self.logger.error("failed to set baud rate: %s" % (e,))
+                        self.logger.error("failed to set baud rate: {0!s}".format(e))
                     self.serial.baudrate = backup
                 else:
                     if self.logger:
-                        self.logger.info("%s baud rate: %s" % ('set' if baudrate else 'get', self.serial.baudrate))
+                        self.logger.info("{0!s} baud rate: {1!s}".format('set' if baudrate else 'get', self.serial.baudrate))
                 self.rfc2217SendSubnegotiation(SERVER_SET_BAUDRATE, struct.pack(b"!I", self.serial.baudrate))
             elif suboption[1:2] == SET_DATASIZE:
                 backup = self.serial.bytesize
@@ -1133,11 +1133,11 @@ class PortManager(object):
                         self.serial.bytesize = datasize
                 except ValueError as e:
                     if self.logger:
-                        self.logger.error("failed to set data size: %s" % (e,))
+                        self.logger.error("failed to set data size: {0!s}".format(e))
                     self.serial.bytesize = backup
                 else:
                     if self.logger:
-                        self.logger.info("%s data size: %s" % ('set' if datasize else 'get', self.serial.bytesize))
+                        self.logger.info("{0!s} data size: {1!s}".format('set' if datasize else 'get', self.serial.bytesize))
                 self.rfc2217SendSubnegotiation(SERVER_SET_DATASIZE, struct.pack(b"!B", self.serial.bytesize))
             elif suboption[1:2] == SET_PARITY:
                 backup = self.serial.parity
@@ -1147,11 +1147,11 @@ class PortManager(object):
                             self.serial.parity = RFC2217_REVERSE_PARITY_MAP[parity]
                 except ValueError as e:
                     if self.logger:
-                        self.logger.error("failed to set parity: %s" % (e,))
+                        self.logger.error("failed to set parity: {0!s}".format(e))
                     self.serial.parity = backup
                 else:
                     if self.logger:
-                        self.logger.info("%s parity: %s" % ('set' if parity else 'get', self.serial.parity))
+                        self.logger.info("{0!s} parity: {1!s}".format('set' if parity else 'get', self.serial.parity))
                 self.rfc2217SendSubnegotiation(
                         SERVER_SET_PARITY,
                         struct.pack(b"!B", RFC2217_PARITY_MAP[self.serial.parity]))
@@ -1163,11 +1163,11 @@ class PortManager(object):
                         self.serial.stopbits = RFC2217_REVERSE_STOPBIT_MAP[stopbits]
                 except ValueError as e:
                     if self.logger:
-                        self.logger.error("failed to set stop bits: %s" % (e,))
+                        self.logger.error("failed to set stop bits: {0!s}".format(e))
                     self.serial.stopbits = backup
                 else:
                     if self.logger:
-                        self.logger.info("%s stop bits: %s" % ('set' if stopbits else 'get', self.serial.stopbits))
+                        self.logger.info("{0!s} stop bits: {1!s}".format('set' if stopbits else 'get', self.serial.stopbits))
                 self.rfc2217SendSubnegotiation(
                         SERVER_SET_STOPSIZE,
                         struct.pack(b"!B", RFC2217_STOPBIT_MAP[self.serial.stopbits]))
@@ -1266,11 +1266,11 @@ class PortManager(object):
             elif suboption[1:2] == SET_LINESTATE_MASK:
                 self.linstate_mask = ord(suboption[2:3])  # ensure it is a number
                 if self.logger:
-                    self.logger.info("line state mask: 0x%02x" % (self.linstate_mask,))
+                    self.logger.info("line state mask: 0x{0:02x}".format(self.linstate_mask))
             elif suboption[1:2] == SET_MODEMSTATE_MASK:
                 self.modemstate_mask = ord(suboption[2:3])  # ensure it is a number
                 if self.logger:
-                    self.logger.info("modem state mask: 0x%02x" % (self.modemstate_mask,))
+                    self.logger.info("modem state mask: 0x{0:02x}".format(self.modemstate_mask))
             elif suboption[1:2] == PURGE_DATA:
                 if suboption[2:3] == PURGE_RECEIVE_BUFFER:
                     self.serial.reset_input_buffer()
@@ -1290,23 +1290,23 @@ class PortManager(object):
                     self.rfc2217SendSubnegotiation(SERVER_PURGE_DATA, PURGE_BOTH_BUFFERS)
                 else:
                     if self.logger:
-                        self.logger.error("undefined PURGE_DATA: %r" % list(suboption[2:]))
+                        self.logger.error("undefined PURGE_DATA: {0!r}".format(list(suboption[2:])))
             else:
                 if self.logger:
-                    self.logger.error("undefined COM_PORT_OPTION: %r" % list(suboption[1:]))
+                    self.logger.error("undefined COM_PORT_OPTION: {0!r}".format(list(suboption[1:])))
         else:
             if self.logger:
-                self.logger.warning("unknown subnegotiation: %r" % (suboption,))
+                self.logger.warning("unknown subnegotiation: {0!r}".format(suboption))
 
 
 # simple client test
 if __name__ == '__main__':
     import sys
     s = Serial('rfc2217://localhost:7000', 115200)
-    sys.stdout.write('%s\n' % s)
+    sys.stdout.write('{0!s}\n'.format(s))
 
     sys.stdout.write("write...\n")
     s.write(b"hello\n")
     s.flush()
-    sys.stdout.write("read: %s\n" % s.read(5))
+    sys.stdout.write("read: {0!s}\n".format(s.read(5)))
     s.close()

--- a/serial/serialcli.py
+++ b/serial/serialcli.py
@@ -43,7 +43,7 @@ class Serial(SerialBase):
             self._port_handle = System.IO.Ports.SerialPort(self.portstr)
         except Exception as msg:
             self._port_handle = None
-            raise SerialException("could not open port %s: %s" % (self.portstr, msg))
+            raise SerialException("could not open port {0!s}: {1!s}".format(self.portstr, msg))
 
         # if RTS and/or DTR are not set before open, they default to True
         if self._rts_state is None:
@@ -96,7 +96,7 @@ class Serial(SerialBase):
         elif self._bytesize == EIGHTBITS:
             self._port_handle.DataBits = 8
         else:
-            raise ValueError("Unsupported number of data bits: %r" % self._bytesize)
+            raise ValueError("Unsupported number of data bits: {0!r}".format(self._bytesize))
 
         if self._parity == PARITY_NONE:
             self._port_handle.Parity = getattr(System.IO.Ports.Parity, 'None')  # reserved keyword in Py3k
@@ -109,7 +109,7 @@ class Serial(SerialBase):
         elif self._parity == PARITY_SPACE:
             self._port_handle.Parity = System.IO.Ports.Parity.Space
         else:
-            raise ValueError("Unsupported parity mode: %r" % self._parity)
+            raise ValueError("Unsupported parity mode: {0!r}".format(self._parity))
 
         if self._stopbits == STOPBITS_ONE:
             self._port_handle.StopBits = System.IO.Ports.StopBits.One
@@ -118,7 +118,7 @@ class Serial(SerialBase):
         elif self._stopbits == STOPBITS_TWO:
             self._port_handle.StopBits = System.IO.Ports.StopBits.Two
         else:
-            raise ValueError("Unsupported number of stop bits: %r" % self._stopbits)
+            raise ValueError("Unsupported number of stop bits: {0!r}".format(self._stopbits))
 
         if self._rtscts and self._xonxoff:
             self._port_handle.Handshake = System.IO.Ports.Handshake.RequestToSendXOnXOff

--- a/serial/serialjava.py
+++ b/serial/serialjava.py
@@ -73,7 +73,7 @@ class Serial(SerialBase):
             self.sPort = portId.open("python serial module", 10)
         except Exception as msg:
             self.sPort = None
-            raise SerialException("Could not open port: %s" % msg)
+            raise SerialException("Could not open port: {0!s}".format(msg))
         self._reconfigurePort()
         self._instream = self.sPort.getInputStream()
         self._outstream = self.sPort.getOutputStream()
@@ -94,7 +94,7 @@ class Serial(SerialBase):
         elif self._bytesize == EIGHTBITS:
             jdatabits = comm.SerialPort.DATABITS_8
         else:
-            raise ValueError("unsupported bytesize: %r" % self._bytesize)
+            raise ValueError("unsupported bytesize: {0!r}".format(self._bytesize))
 
         if self._stopbits == STOPBITS_ONE:
             jstopbits = comm.SerialPort.STOPBITS_1
@@ -103,7 +103,7 @@ class Serial(SerialBase):
         elif self._stopbits == STOPBITS_TWO:
             jstopbits = comm.SerialPort.STOPBITS_2
         else:
-            raise ValueError("unsupported number of stopbits: %r" % self._stopbits)
+            raise ValueError("unsupported number of stopbits: {0!r}".format(self._stopbits))
 
         if self._parity == PARITY_NONE:
             jparity = comm.SerialPort.PARITY_NONE
@@ -116,7 +116,7 @@ class Serial(SerialBase):
         elif self._parity == PARITY_SPACE:
             jparity = comm.SerialPort.PARITY_SPACE
         else:
-            raise ValueError("unsupported parity type: %r" % self._parity)
+            raise ValueError("unsupported parity type: {0!r}".format(self._parity))
 
         jflowin = jflowout = 0
         if self._rtscts:
@@ -177,7 +177,7 @@ class Serial(SerialBase):
         if not self.sPort:
             raise portNotOpenError
         if not isinstance(data, (bytes, bytearray)):
-            raise TypeError('expected %s or bytearray, got %s' % (bytes, type(data)))
+            raise TypeError('expected {0!s} or bytearray, got {1!s}'.format(bytes, type(data)))
         self._outstream.write(data)
         return len(data)
 

--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -34,15 +34,15 @@ don't know how to number ttys on this system.
 ! Use an explicit path (eg /dev/ttyS1) or send this information to
 ! the author of this module:
 
-sys.platform = %r
-os.name = %r
-serialposix.py version = %s
+sys.platform = {0!r}
+os.name = {1!r}
+serialposix.py version = {2!s}
 
 also add the device name of the serial port and where the
 counting starts for the first serial port.
 e.g. 'first serial port: /dev/ttyS0'
 and with a bit luck you can get this module running...
-""" % (sys.platform, os.name, serial.VERSION))
+""".format(sys.platform, os.name, serial.VERSION))
         raise NotImplementedError('no number-to-device mapping defined on this platform')
 
     def _set_special_baudrate(self, baudrate):
@@ -108,7 +108,7 @@ if plat[:5] == 'linux':    # Linux (confirmed)
         }
 
         def number_to_device(self, port_number):
-            return '/dev/ttyS%d' % (port_number,)
+            return '/dev/ttyS{0:d}'.format(port_number)
 
         def _set_special_baudrate(self, baudrate):
             # right size is 44 on x86_64, allow for some growth
@@ -124,7 +124,7 @@ if plat[:5] == 'linux':    # Linux (confirmed)
                 # set serial_struct
                 fcntl.ioctl(self.fd, TCSETS2, buf)
             except IOError as e:
-                raise ValueError('Failed to set custom baud rate (%s): %s' % (baudrate, e))
+                raise ValueError('Failed to set custom baud rate ({0!s}): {1!s}'.format(baudrate, e))
 
         def _set_rs485_mode(self, rs485_settings):
             buf = array.array('i', [0] * 8)  # flags, delaytx, delayrx, padding
@@ -149,7 +149,7 @@ if plat[:5] == 'linux':    # Linux (confirmed)
                     buf[0] = 0  # clear SER_RS485_ENABLED
                 fcntl.ioctl(self.fd, TIOCSRS485, buf)
             except IOError as e:
-                raise ValueError('Failed to set RS485 mode: %s' % (e,))
+                raise ValueError('Failed to set RS485 mode: {0!s}'.format(e))
 
 
 elif plat == 'cygwin':       # cygwin/win32 (confirmed)
@@ -170,18 +170,18 @@ elif plat == 'cygwin':       # cygwin/win32 (confirmed)
         }
 
         def number_to_device(self, port_number):
-            return '/dev/com%d' % (port_number + 1,)
+            return '/dev/com{0:d}'.format(port_number + 1)
 
 
 elif plat[:7] == 'openbsd':    # OpenBSD
     class PlatformSpecific(PlatformSpecificBase):
         def number_to_device(self, port_number):
-            return '/dev/cua%02d' % (port_number,)
+            return '/dev/cua{0:02d}'.format(port_number)
 
 elif plat[:3] == 'bsd' or plat[:7] == 'freebsd':
     class PlatformSpecific(PlatformSpecificBase):
         def number_to_device(self, port_number):
-            return '/dev/cuad%d' % (port_number,)
+            return '/dev/cuad{0:d}'.format(port_number)
 
 elif plat[:6] == 'darwin':   # OS X
     import array
@@ -189,7 +189,7 @@ elif plat[:6] == 'darwin':   # OS X
 
     class PlatformSpecific(PlatformSpecificBase):
         def number_to_device(self, port_number):
-            return '/dev/cuad%d' % (port_number,)
+            return '/dev/cuad{0:d}'.format(port_number)
 
         osx_version = os.uname()[2].split('.')
         # Tiger or above can support arbitrary serial speeds
@@ -203,17 +203,17 @@ elif plat[:6] == 'darwin':   # OS X
 elif plat[:6] == 'netbsd':   # NetBSD 1.6 testing by Erk
     class PlatformSpecific(PlatformSpecificBase):
         def number_to_device(self, port_number):
-            return '/dev/dty%02d' % (port_number,)
+            return '/dev/dty{0:02d}'.format(port_number)
 
 elif plat[:4] == 'irix':     # IRIX (partially tested)
     class PlatformSpecific(PlatformSpecificBase):
         def number_to_device(self, port_number):
-            return '/dev/ttyf%d' % (port_number + 1,)  # XXX different device names depending on flow control
+            return '/dev/ttyf{0:d}'.format(port_number + 1)  # XXX different device names depending on flow control
 
 elif plat[:2] == 'hp':       # HP-UX (not tested)
     class PlatformSpecific(PlatformSpecificBase):
         def number_to_device(self, port_number):
-            return '/dev/tty%dp0' % (port_number + 1,)
+            return '/dev/tty{0:d}p0'.format(port_number + 1)
 
 elif plat[:5] == 'sunos':    # Solaris/SunOS (confirmed)
     class PlatformSpecific(PlatformSpecificBase):
@@ -223,7 +223,7 @@ elif plat[:5] == 'sunos':    # Solaris/SunOS (confirmed)
 elif plat[:3] == 'aix':      # AIX
     class PlatformSpecific(PlatformSpecificBase):
         def number_to_device(self, port_number):
-            return '/dev/tty%d' % (port_number,)
+            return '/dev/tty{0:d}'.format(port_number)
 
 else:
     class PlatformSpecific(PlatformSpecificBase):
@@ -291,7 +291,7 @@ class Serial(SerialBase, PlatformSpecific):
             self.fd = os.open(self.portstr, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
         except OSError as msg:
             self.fd = None
-            raise SerialException(msg.errno, "could not open port %s: %s" % (self._port, msg))
+            raise SerialException(msg.errno, "could not open port {0!s}: {1!s}".format(self._port, msg))
         #~ fcntl.fcntl(self.fd, fcntl.F_SETFL, 0)  # set blocking
 
         try:
@@ -327,7 +327,7 @@ class Serial(SerialBase, PlatformSpecific):
             orig_attr = termios.tcgetattr(self.fd)
             iflag, oflag, cflag, lflag, ispeed, ospeed, cc = orig_attr
         except termios.error as msg:      # if a port is nonexistent but has a /dev file, it'll fail here
-            raise SerialException("Could not configure port: %s" % msg)
+            raise SerialException("Could not configure port: {0!s}".format(msg))
         # set up raw mode / no echo / binary
         cflag |= (termios.CLOCAL | termios.CREAD)
         lflag &= ~(termios.ICANON | termios.ECHO | termios.ECHOE |
@@ -346,7 +346,7 @@ class Serial(SerialBase, PlatformSpecific):
 
         # setup baud rate
         try:
-            ispeed = ospeed = getattr(termios, 'B%s' % (self._baudrate))
+            ispeed = ospeed = getattr(termios, 'B{0!s}'.format((self._baudrate)))
         except AttributeError:
             try:
                 ispeed = ospeed = self.BAUDRATE_CONSTANTS[self._baudrate]
@@ -357,10 +357,10 @@ class Serial(SerialBase, PlatformSpecific):
                 try:
                     custom_baud = int(self._baudrate)  # store for later
                 except ValueError:
-                    raise ValueError('Invalid baud rate: %r' % self._baudrate)
+                    raise ValueError('Invalid baud rate: {0!r}'.format(self._baudrate))
                 else:
                     if custom_baud < 0:
-                        raise ValueError('Invalid baud rate: %r' % self._baudrate)
+                        raise ValueError('Invalid baud rate: {0!r}'.format(self._baudrate))
 
         # setup char len
         cflag &= ~termios.CSIZE
@@ -373,7 +373,7 @@ class Serial(SerialBase, PlatformSpecific):
         elif self._bytesize == 5:
             cflag |= termios.CS5
         else:
-            raise ValueError('Invalid char len: %r' % self._bytesize)
+            raise ValueError('Invalid char len: {0!r}'.format(self._bytesize))
         # setup stop bits
         if self._stopbits == serial.STOPBITS_ONE:
             cflag &= ~(termios.CSTOPB)
@@ -382,7 +382,7 @@ class Serial(SerialBase, PlatformSpecific):
         elif self._stopbits == serial.STOPBITS_TWO:
             cflag |= (termios.CSTOPB)
         else:
-            raise ValueError('Invalid stop bit specification: %r' % self._stopbits)
+            raise ValueError('Invalid stop bit specification: {0!r}'.format(self._stopbits))
         # setup parity
         iflag &= ~(termios.INPCK | termios.ISTRIP)
         if self._parity == serial.PARITY_NONE:
@@ -398,7 +398,7 @@ class Serial(SerialBase, PlatformSpecific):
             cflag |= (termios.PARENB | CMSPAR)
             cflag &= ~(termios.PARODD)
         else:
-            raise ValueError('Invalid parity: %r' % self._parity)
+            raise ValueError('Invalid parity: {0!r}'.format(self._parity))
         # setup flow control
         # xonxoff
         if hasattr(termios, 'IXANY'):
@@ -427,11 +427,11 @@ class Serial(SerialBase, PlatformSpecific):
         # buffer
         # vmin "minimal number of characters to be read. 0 for non blocking"
         if vmin < 0 or vmin > 255:
-            raise ValueError('Invalid vmin: %r ' % vmin)
+            raise ValueError('Invalid vmin: {0!r} '.format(vmin))
         cc[termios.VMIN] = vmin
         # vtime
         if vtime < 0 or vtime > 255:
-            raise ValueError('Invalid vtime: %r' % vtime)
+            raise ValueError('Invalid vtime: {0!r}'.format(vtime))
         cc[termios.VTIME] = vtime
         # activate settings
         if force_update or [iflag, oflag, cflag, lflag, ispeed, ospeed, cc] != orig_attr:
@@ -502,13 +502,13 @@ class Serial(SerialBase, PlatformSpecific):
                 # this is for Python 3.x where select.error is a subclass of
                 # OSError ignore EAGAIN errors. all other errors are shown
                 if e.errno != errno.EAGAIN:
-                    raise SerialException('read failed: %s' % (e,))
+                    raise SerialException('read failed: {0!s}'.format(e))
             except select.error as e:
                 # this is for Python 2.x
                 # ignore EAGAIN errors. all other errors are shown
                 # see also http://www.python.org/dev/peps/pep-3151/#select
                 if e[0] != errno.EAGAIN:
-                    raise SerialException('read failed: %s' % (e,))
+                    raise SerialException('read failed: {0!s}'.format(e))
         return bytes(read)
 
     def write(self, data):
@@ -544,7 +544,7 @@ class Serial(SerialBase, PlatformSpecific):
                 raise
             except OSError as v:
                 if v.errno != errno.EAGAIN:
-                    raise SerialException('write failed: %s' % (v,))
+                    raise SerialException('write failed: {0!s}'.format(v))
                 # still calculate and check timeout
                 if timeout and timeout - time.time() < 0:
                     raise writeTimeoutError
@@ -750,10 +750,10 @@ class VTIMESerial(Serial):
             orig_attr = termios.tcgetattr(self.fd)
             iflag, oflag, cflag, lflag, ispeed, ospeed, cc = orig_attr
         except termios.error as msg:      # if a port is nonexistent but has a /dev file, it'll fail here
-            raise serial.SerialException("Could not configure port: %s" % msg)
+            raise serial.SerialException("Could not configure port: {0!s}".format(msg))
 
         if vtime < 0 or vtime > 255:
-            raise ValueError('Invalid vtime: %r' % vtime)
+            raise ValueError('Invalid vtime: {0!r}'.format(vtime))
         cc[termios.VTIME] = vtime
         cc[termios.VMIN] = vmin
 

--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -55,7 +55,7 @@ def to_bytes(seq):
     elif isinstance(seq, memoryview):
         return seq.tobytes()
     elif isinstance(seq, unicode):
-        raise TypeError('unicode strings are not supported, please encode to bytes: %r' % (seq,))
+        raise TypeError('unicode strings are not supported, please encode to bytes: {0!r}'.format(seq))
     else:
         b = bytearray()
         for item in seq:
@@ -170,7 +170,7 @@ class SerialBase(io.RawIOBase):
         if 'interCharTimeout' in kwargs:
             self.inter_byte_timeout = kwargs.pop('interCharTimeout')
         if kwargs:
-            raise ValueError('unexpected keyword arguments: %r' % (kwargs,))
+            raise ValueError('unexpected keyword arguments: {0!r}'.format(kwargs))
 
         if port is not None:
             self.open()
@@ -223,10 +223,10 @@ class SerialBase(io.RawIOBase):
         try:
             b = int(baudrate)
         except TypeError:
-            raise ValueError("Not a valid baudrate: %r" % (baudrate,))
+            raise ValueError("Not a valid baudrate: {0!r}".format(baudrate))
         else:
             if b <= 0:
-                raise ValueError("Not a valid baudrate: %r" % (baudrate,))
+                raise ValueError("Not a valid baudrate: {0!r}".format(baudrate))
             self._baudrate = b
             if self.is_open:
                 self._reconfigure_port()
@@ -240,7 +240,7 @@ class SerialBase(io.RawIOBase):
     def bytesize(self, bytesize):
         """Change byte size."""
         if bytesize not in self.BYTESIZES:
-            raise ValueError("Not a valid byte size: %r" % (bytesize,))
+            raise ValueError("Not a valid byte size: {0!r}".format(bytesize))
         self._bytesize = bytesize
         if self.is_open:
             self._reconfigure_port()
@@ -254,7 +254,7 @@ class SerialBase(io.RawIOBase):
     def parity(self, parity):
         """Change parity setting."""
         if parity not in self.PARITIES:
-            raise ValueError("Not a valid parity: %r" % (parity,))
+            raise ValueError("Not a valid parity: {0!r}".format(parity))
         self._parity = parity
         if self.is_open:
             self._reconfigure_port()
@@ -268,7 +268,7 @@ class SerialBase(io.RawIOBase):
     def stopbits(self, stopbits):
         """Change stop bits size."""
         if stopbits not in self.STOPBITS:
-            raise ValueError("Not a valid stop bit size: %r" % (stopbits,))
+            raise ValueError("Not a valid stop bit size: {0!r}".format(stopbits))
         self._stopbits = stopbits
         if self.is_open:
             self._reconfigure_port()
@@ -285,9 +285,9 @@ class SerialBase(io.RawIOBase):
             try:
                 timeout + 1     # test if it's a number, will throw a TypeError if not...
             except TypeError:
-                raise ValueError("Not a valid timeout: %r" % (timeout,))
+                raise ValueError("Not a valid timeout: {0!r}".format(timeout))
             if timeout < 0:
-                raise ValueError("Not a valid timeout: %r" % (timeout,))
+                raise ValueError("Not a valid timeout: {0!r}".format(timeout))
         self._timeout = timeout
         if self.is_open:
             self._reconfigure_port()
@@ -302,11 +302,11 @@ class SerialBase(io.RawIOBase):
         """Change timeout setting."""
         if timeout is not None:
             if timeout < 0:
-                raise ValueError("Not a valid timeout: %r" % (timeout,))
+                raise ValueError("Not a valid timeout: {0!r}".format(timeout))
             try:
                 timeout + 1     # test if it's a number, will throw a TypeError if not...
             except TypeError:
-                raise ValueError("Not a valid timeout: %r" % timeout)
+                raise ValueError("Not a valid timeout: {0!r}".format(timeout))
 
         self._write_timeout = timeout
         if self.is_open:
@@ -322,11 +322,11 @@ class SerialBase(io.RawIOBase):
         """Change inter-byte timeout setting."""
         if ic_timeout is not None:
             if ic_timeout < 0:
-                raise ValueError("Not a valid timeout: %r" % ic_timeout)
+                raise ValueError("Not a valid timeout: {0!r}".format(ic_timeout))
             try:
                 ic_timeout + 1     # test if it's a number, will throw a TypeError if not...
             except TypeError:
-                raise ValueError("Not a valid timeout: %r" % ic_timeout)
+                raise ValueError("Not a valid timeout: {0!r}".format(ic_timeout))
 
         self._inter_byte_timeout = ic_timeout
         if self.is_open:
@@ -447,7 +447,7 @@ class SerialBase(io.RawIOBase):
 
     def __repr__(self):
         """String representation of the current port settings and its state."""
-        return "%s<id=0x%x, open=%s>(port=%r, baudrate=%r, bytesize=%r, parity=%r, stopbits=%r, timeout=%r, xonxoff=%r, rtscts=%r, dsrdtr=%r)" % (
+        return "{0!s}<id=0x{1:x}, open={2!s}>(port={3!r}, baudrate={4!r}, bytesize={5!r}, parity={6!r}, stopbits={7!r}, timeout={8!r}, xonxoff={9!r}, rtscts={10!r}, dsrdtr={11!r})".format(
                 self.__class__.__name__,
                 id(self),
                 self.is_open,
@@ -459,7 +459,7 @@ class SerialBase(io.RawIOBase):
                 self.timeout,
                 self.xonxoff,
                 self.rtscts,
-                self.dsrdtr,
+                self.dsrdtr
         )
 
     #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
@@ -610,9 +610,9 @@ class SerialBase(io.RawIOBase):
 if __name__ == '__main__':
     import sys
     s = SerialBase()
-    sys.stdout.write('port name:  %s\n' % s.name)
-    sys.stdout.write('baud rates: %s\n' % s.BAUDRATES)
-    sys.stdout.write('byte sizes: %s\n' % s.BYTESIZES)
-    sys.stdout.write('parities:   %s\n' % s.PARITIES)
-    sys.stdout.write('stop bits:  %s\n' % s.STOPBITS)
-    sys.stdout.write('%s\n' % s)
+    sys.stdout.write('port name:  {0!s}\n'.format(s.name))
+    sys.stdout.write('baud rates: {0!s}\n'.format(s.BAUDRATES))
+    sys.stdout.write('byte sizes: {0!s}\n'.format(s.BYTESIZES))
+    sys.stdout.write('parities:   {0!s}\n'.format(s.PARITIES))
+    sys.stdout.write('stop bits:  {0!s}\n'.format(s.STOPBITS))
+    sys.stdout.write('{0!s}\n'.format(s))

--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -63,7 +63,7 @@ class Serial(SerialBase):
                 0)
         if self._port_handle == win32.INVALID_HANDLE_VALUE:
             self._port_handle = None    # 'cause __del__ is called anyway
-            raise SerialException("could not open port %r: %r" % (self.portstr, ctypes.WinError()))
+            raise SerialException("could not open port {0!r}: {1!r}".format(self.portstr, ctypes.WinError()))
 
         try:
             self._overlapped_read = win32.OVERLAPPED()
@@ -144,7 +144,7 @@ class Serial(SerialBase):
         elif self._bytesize == serial.EIGHTBITS:
             comDCB.ByteSize = 8
         else:
-            raise ValueError("Unsupported number of data bits: %r" % self._bytesize)
+            raise ValueError("Unsupported number of data bits: {0!r}".format(self._bytesize))
 
         if self._parity == serial.PARITY_NONE:
             comDCB.Parity = win32.NOPARITY
@@ -162,7 +162,7 @@ class Serial(SerialBase):
             comDCB.Parity = win32.SPACEPARITY
             comDCB.fParity = 1  # Enable Parity Check
         else:
-            raise ValueError("Unsupported parity mode: %r" % self._parity)
+            raise ValueError("Unsupported parity mode: {0!r}".format(self._parity))
 
         if self._stopbits == serial.STOPBITS_ONE:
             comDCB.StopBits = win32.ONESTOPBIT
@@ -171,7 +171,7 @@ class Serial(SerialBase):
         elif self._stopbits == serial.STOPBITS_TWO:
             comDCB.StopBits = win32.TWOSTOPBITS
         else:
-            raise ValueError("Unsupported number of stop bits: %r" % self._stopbits)
+            raise ValueError("Unsupported number of stop bits: {0!r}".format(self._stopbits))
 
         comDCB.fBinary = 1  # Enable Binary Transmission
         # Char. w/ Parity-Err are replaced with 0xff (if fErrorChar is set to TRUE)
@@ -186,24 +186,24 @@ class Serial(SerialBase):
             # XXX verify if platform really does not have a setting for those
             if not self._rs485_mode.rts_level_for_tx:
                 raise ValueError(
-                        'Unsupported value for RS485Settings.rts_level_for_tx: %r' % (
-                            self._rs485_mode.rts_level_for_tx,))
+                        'Unsupported value for RS485Settings.rts_level_for_tx: {0!r}'.format(
+                            self._rs485_mode.rts_level_for_tx))
             if self._rs485_mode.rts_level_for_rx:
                 raise ValueError(
-                        'Unsupported value for RS485Settings.rts_level_for_rx: %r' % (
-                            self._rs485_mode.rts_level_for_rx,))
+                        'Unsupported value for RS485Settings.rts_level_for_rx: {0!r}'.format(
+                            self._rs485_mode.rts_level_for_rx))
             if self._rs485_mode.delay_before_tx is not None:
                 raise ValueError(
-                        'Unsupported value for RS485Settings.delay_before_tx: %r' % (
-                            self._rs485_mode.delay_before_tx,))
+                        'Unsupported value for RS485Settings.delay_before_tx: {0!r}'.format(
+                            self._rs485_mode.delay_before_tx))
             if self._rs485_mode.delay_before_rx is not None:
                 raise ValueError(
-                        'Unsupported value for RS485Settings.delay_before_rx: %r' % (
-                            self._rs485_mode.delay_before_rx,))
+                        'Unsupported value for RS485Settings.delay_before_rx: {0!r}'.format(
+                            self._rs485_mode.delay_before_rx))
             if self._rs485_mode.loopback:
                 raise ValueError(
-                        'Unsupported value for RS485Settings.loopback: %r' % (
-                            self._rs485_mode.loopback,))
+                        'Unsupported value for RS485Settings.loopback: {0!r}'.format(
+                            self._rs485_mode.loopback))
             comDCB.fRtsControl = win32.RTS_CONTROL_TOGGLE
             comDCB.fOutxCtsFlow = 0
 
@@ -221,7 +221,7 @@ class Serial(SerialBase):
         comDCB.XoffChar = serial.XOFF
 
         if not win32.SetCommState(self._port_handle, ctypes.byref(comDCB)):
-            raise SerialException("Cannot configure port, something went wrong. Original message: %r" % ctypes.WinError())
+            raise SerialException("Cannot configure port, something went wrong. Original message: {0!r}".format(ctypes.WinError()))
 
     #~ def __del__(self):
         #~ self.close()
@@ -277,7 +277,7 @@ class Serial(SerialBase):
                 rc = win32.DWORD()
                 read_ok = win32.ReadFile(self._port_handle, buf, n, ctypes.byref(rc), ctypes.byref(self._overlapped_read))
                 if not read_ok and win32.GetLastError() not in (win32.ERROR_SUCCESS, win32.ERROR_IO_PENDING):
-                    raise SerialException("ReadFile failed (%r)" % ctypes.WinError())
+                    raise SerialException("ReadFile failed ({0!r})".format(ctypes.WinError()))
                 win32.GetOverlappedResult(self._port_handle, ctypes.byref(self._overlapped_read), ctypes.byref(rc), True)
                 read = buf.raw[:rc.value]
             else:
@@ -299,7 +299,7 @@ class Serial(SerialBase):
             n = win32.DWORD()
             err = win32.WriteFile(self._port_handle, data, len(data), ctypes.byref(n), self._overlapped_write)
             if not err and win32.GetLastError() != win32.ERROR_IO_PENDING:
-                raise SerialException("WriteFile failed (%r)" % ctypes.WinError())
+                raise SerialException("WriteFile failed ({0!r})".format(ctypes.WinError()))
             if self._write_timeout != 0:  # if blocking (None) or w/ write timeout (>0)
                 # Wait for the write to complete.
                 #~ win32.WaitForSingleObject(self._overlapped_write.hEvent, win32.INFINITE)

--- a/serial/tools/hexlify_codec.py
+++ b/serial/tools/hexlify_codec.py
@@ -66,7 +66,7 @@ class IncrementalEncoder(codecs.IncrementalEncoder):
                 state = 0
             else:
                 if self.errors == 'strict':
-                    raise UnicodeError('non-hex digit found: %r' % c)
+                    raise UnicodeError('non-hex digit found: {0!r}'.format(c))
         self.state = state
         return serial.to_bytes(encoded)
 

--- a/serial/tools/list_ports.py
+++ b/serial/tools/list_ports.py
@@ -29,7 +29,7 @@ elif os.name == 'posix':
     from serial.tools.list_ports_posix import comports
 #~ elif os.name == 'java':
 else:
-    raise ImportError("Sorry: no implementation for your platform ('%s') available" % (os.name,))
+    raise ImportError("Sorry: no implementation for your platform ('{0!s}') available".format(os.name))
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -79,7 +79,7 @@ def main():
     # get iteraror w/ or w/o filter
     if args.regexp:
         if not args.quiet:
-            sys.stderr.write("Filtered list with regexp: %r\n" % (args.regexp,))
+            sys.stderr.write("Filtered list with regexp: {0!r}\n".format(args.regexp))
         iterator = sorted(grep(args.regexp))
     else:
         iterator = sorted(comports())

--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -20,8 +20,8 @@ class SysFS(list_ports_common.ListPortInfo):
         super(SysFS, self).__init__(device)
         self.name = os.path.basename(device)
         self.usb_device_path = None
-        if os.path.exists('/sys/class/tty/%s/device' % (self.name,)):
-            self.device_path = os.path.realpath('/sys/class/tty/%s/device' % (self.name,))
+        if os.path.exists('/sys/class/tty/{0!s}/device'.format(self.name)):
+            self.device_path = os.path.realpath('/sys/class/tty/{0!s}/device'.format(self.name))
             self.subsystem = os.path.basename(os.path.realpath(os.path.join(self.device_path, 'subsystem')))
         else:
             self.device_path = None
@@ -81,4 +81,4 @@ def comports():
 # test
 if __name__ == '__main__':
     for port, desc, hwid in sorted(comports()):
-        print("%s: %s [%s]" % (port, desc, hwid))
+        print("{0!s}: {1!s} [{2!s}]".format(port, desc, hwid))

--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -255,4 +255,4 @@ def comports():
 # test
 if __name__ == '__main__':
     for port, desc, hwid in sorted(comports()):
-        print("%s: %s [%s]" % (port, desc, hwid))
+        print("{0!s}: {1!s} [{2!s}]".format(port, desc, hwid))

--- a/serial/tools/list_ports_posix.py
+++ b/serial/tools/list_ports_posix.py
@@ -87,16 +87,16 @@ don't know how to enumerate ttys on this system.
 ! I you know how the serial ports are named send this information to
 ! the author of this module:
 
-sys.platform = %r
-os.name = %r
-pySerial version = %s
+sys.platform = {0!r}
+os.name = {1!r}
+pySerial version = {2!s}
 
 also add the naming scheme of the serial ports and with a bit luck you can get
 this module running...
-""" % (sys.platform, os.name, serial.VERSION))
-    raise ImportError("Sorry: no implementation for your platform ('%s') available" % (os.name,))
+""".format(sys.platform, os.name, serial.VERSION))
+    raise ImportError("Sorry: no implementation for your platform ('{0!s}') available".format(os.name))
 
 # test
 if __name__ == '__main__':
     for port, desc, hwid in sorted(comports()):
-        print("%s: %s [%s]" % (port, desc, hwid))
+        print("{0!s}: {1!s} [{2!s}]".format(port, desc, hwid))

--- a/serial/tools/list_ports_windows.py
+++ b/serial/tools/list_ports_windows.py
@@ -65,12 +65,12 @@ class GUID(ctypes.Structure):
     ]
 
     def __str__(self):
-        return "{%08x-%04x-%04x-%s-%s}" % (
+        return "{{{0:08x}-{1:04x}-{2:04x}-{3!s}-{4!s}}}".format(
             self.Data1,
             self.Data2,
             self.Data3,
-            ''.join(["%02x" % d for d in self.Data4[:2]]),
-            ''.join(["%02x" % d for d in self.Data4[2:]]),
+            ''.join(["{0:02x}".format(d) for d in self.Data4[:2]]),
+            ''.join(["{0:02x}".format(d) for d in self.Data4[2:]])
         )
 
 
@@ -83,7 +83,7 @@ class SP_DEVINFO_DATA(ctypes.Structure):
     ]
 
     def __str__(self):
-        return "ClassGuid:%s DevInst:%s" % (self.ClassGuid, self.DevInst)
+        return "ClassGuid:{0!s} DevInst:{1!s}".format(self.ClassGuid, self.DevInst)
 
 PSP_DEVINFO_DATA = ctypes.POINTER(SP_DEVINFO_DATA)
 
@@ -244,7 +244,7 @@ def comports():
                     location = []
                     for g in m:
                         if g.group(1):
-                            location.append('%d' % (int(g.group(1)) + 1))
+                            location.append('{0:d}'.format((int(g.group(1)) + 1)))
                         else:
                             if len(location) > 1:
                                 location.append('.')
@@ -291,4 +291,4 @@ def comports():
 # test
 if __name__ == '__main__':
     for port, desc, hwid in sorted(comports()):
-        print("%s: %s [%s]" % (port, desc, hwid))
+        print("{0!s}: {1!s} [{2!s}]".format(port, desc, hwid))

--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -145,7 +145,7 @@ elif os.name == 'posix':
             termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old)
 
 else:
-    raise NotImplementedError("Sorry no implementation for your platform (%s) available." % sys.platform)
+    raise NotImplementedError("Sorry no implementation for your platform ({0!s}) available.".format(sys.platform))
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/serial/urlhandler/protocol_alt.py
+++ b/serial/urlhandler/protocol_alt.py
@@ -28,21 +28,21 @@ def serial_class_for_url(url):
     """extract host and port from an URL string"""
     parts = urlparse.urlsplit(url)
     if parts.scheme != 'alt':
-        raise serial.SerialException('expected a string in the form "alt://port[?option[=value][&option[=value]]]": not starting with alt:// (%r)' % (parts.scheme,))
+        raise serial.SerialException('expected a string in the form "alt://port[?option[=value][&option[=value]]]": not starting with alt:// ({0!r})'.format(parts.scheme))
     class_name = 'Serial'
     try:
         for option, values in urlparse.parse_qs(parts.query, True).items():
             if option == 'class':
                 class_name = values[0]
             else:
-                raise ValueError('unknown option: %r' % (option,))
+                raise ValueError('unknown option: {0!r}'.format(option))
     except ValueError as e:
-        raise serial.SerialException('expected a string in the form "alt://port[?option[=value][&option[=value]]]": %s' % e)
+        raise serial.SerialException('expected a string in the form "alt://port[?option[=value][&option[=value]]]": {0!s}'.format(e))
     if not hasattr(serial, class_name):
-        raise ValueError('unknown class: %r' % (class_name,))
+        raise ValueError('unknown class: {0!r}'.format(class_name))
     cls = getattr(serial, class_name)
     if not issubclass(cls, serial.Serial):
-        raise ValueError('class %r is not an instance of Serial' % (class_name,))
+        raise ValueError('class {0!r} is not an instance of Serial'.format(class_name))
     return (''.join([parts.netloc, parts.path]), cls)
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/serial/urlhandler/protocol_hwgrep.py
+++ b/serial/urlhandler/protocol_hwgrep.py
@@ -58,12 +58,12 @@ class Serial(serial.Serial):
                 # pick n'th element
                 n = int(value) - 1
                 if n < 1:
-                    raise ValueError('option "n" expects a positive integer larger than 1: %r' % (value,))
+                    raise ValueError('option "n" expects a positive integer larger than 1: {0!r}'.format(value))
             elif option == 'skip_busy':
                 # open to test if port is available. not the nicest way..
                 test_open = True
             else:
-                raise ValueError('unknown option: %r' % (option,))
+                raise ValueError('unknown option: {0!r}'.format(option))
         # use a for loop to get the 1st element from the generator
         for port, desc, hwid in sorted(serial.tools.list_ports.grep(regexp)):
             if test_open:
@@ -79,7 +79,7 @@ class Serial(serial.Serial):
                 continue
             return port
         else:
-            raise serial.SerialException('no ports found matching regexp %r' % (url,))
+            raise serial.SerialException('no ports found matching regexp {0!r}'.format(url))
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if __name__ == '__main__':

--- a/serial/urlhandler/protocol_loop.py
+++ b/serial/urlhandler/protocol_loop.py
@@ -91,7 +91,7 @@ class Serial(SerialBase):
         """
         # not that's it of any real use, but it helps in the unit tests
         if not isinstance(self._baudrate, numbers.Integral) or not 0 < self._baudrate < 2**32:
-            raise ValueError("invalid baudrate: %r" % (self._baudrate))
+            raise ValueError("invalid baudrate: {0!r}".format((self._baudrate)))
         if self.logger:
             self.logger.info('_reconfigure_port()')
 
@@ -99,7 +99,7 @@ class Serial(SerialBase):
         """extract host and port from an URL string"""
         parts = urlparse.urlsplit(url)
         if parts.scheme != "loop":
-            raise SerialException('expected a string in the form "loop://[?logging={debug|info|warning|error}]": not starting with loop:// (%r)' % (parts.scheme,))
+            raise SerialException('expected a string in the form "loop://[?logging={{debug|info|warning|error}}]": not starting with loop:// ({0!r})'.format(parts.scheme))
         try:
             # process options now, directly altering self
             for option, values in urlparse.parse_qs(parts.query, True).items():
@@ -109,9 +109,9 @@ class Serial(SerialBase):
                     self.logger.setLevel(LOGGER_LEVELS[values[0]])
                     self.logger.debug('enabled logging')
                 else:
-                    raise ValueError('unknown option: %r' % (option,))
+                    raise ValueError('unknown option: {0!r}'.format(option))
         except ValueError as e:
-            raise SerialException('expected a string in the form "loop://[?logging={debug|info|warning|error}]": %s' % e)
+            raise SerialException('expected a string in the form "loop://[?logging={{debug|info|warning|error}}]": {0!s}'.format(e))
 
     #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
@@ -123,7 +123,7 @@ class Serial(SerialBase):
         if self.logger:
             # attention the logged value can differ from return value in
             # threaded environments...
-            self.logger.debug('in_waiting -> %d' % (self.queue.qsize(),))
+            self.logger.debug('in_waiting -> {0:d}'.format(self.queue.qsize()))
         return self.queue.qsize()
 
     def read(self, size=1):
@@ -212,17 +212,17 @@ class Serial(SerialBase):
         possible.
         """
         if self.logger:
-            self.logger.info('_update_break_state(%r)' % (self._break_state,))
+            self.logger.info('_update_break_state({0!r})'.format(self._break_state))
 
     def _update_rts_state(self):
         """Set terminal status line: Request To Send"""
         if self.logger:
-            self.logger.info('_update_rts_state(%r) -> state of CTS' % (self._rts_state,))
+            self.logger.info('_update_rts_state({0!r}) -> state of CTS'.format(self._rts_state))
 
     def _update_dtr_state(self):
         """Set terminal status line: Data Terminal Ready"""
         if self.logger:
-            self.logger.info('_update_dtr_state(%r) -> state of DSR' % (self._dtr_state,))
+            self.logger.info('_update_dtr_state({0!r}) -> state of DSR'.format(self._dtr_state))
 
     @property
     def cts(self):
@@ -230,14 +230,14 @@ class Serial(SerialBase):
         if not self.is_open:
             raise portNotOpenError
         if self.logger:
-            self.logger.info('CTS -> state of RTS (%r)' % (self._rts_state,))
+            self.logger.info('CTS -> state of RTS ({0!r})'.format(self._rts_state))
         return self._rts_state
 
     @property
     def dsr(self):
         """Read terminal status line: Data Set Ready"""
         if self.logger:
-            self.logger.info('DSR -> state of DTR (%r)' % (self._dtr_state,))
+            self.logger.info('DSR -> state of DTR ({0!r})'.format(self._dtr_state))
         return self._dtr_state
 
     @property
@@ -266,11 +266,11 @@ class Serial(SerialBase):
 if __name__ == '__main__':
     import sys
     s = Serial('loop://')
-    sys.stdout.write('%s\n' % s)
+    sys.stdout.write('{0!s}\n'.format(s))
 
     sys.stdout.write("write...\n")
     s.write("hello\n")
     s.flush()
-    sys.stdout.write("read: %s\n" % s.read(5))
+    sys.stdout.write("read: {0!s}\n".format(s.read(5)))
 
     s.close()

--- a/serial/urlhandler/protocol_socket.py
+++ b/serial/urlhandler/protocol_socket.py
@@ -59,7 +59,7 @@ class Serial(SerialBase):
             self._socket = socket.create_connection(self.from_url(self.portstr))
         except Exception as msg:
             self._socket = None
-            raise SerialException("Could not open port %s: %s" % (self.portstr, msg))
+            raise SerialException("Could not open port {0!s}: {1!s}".format(self.portstr, msg))
 
         self._socket.settimeout(POLL_TIMEOUT)  # used for write timeout support :/
 
@@ -103,7 +103,7 @@ class Serial(SerialBase):
         """extract host and port from an URL string"""
         parts = urlparse.urlsplit(url)
         if parts.scheme != "socket":
-            raise SerialException('expected a string in the form "socket://<host>:<port>[?logging={debug|info|warning|error}]": not starting with socket:// (%r)' % (parts.scheme,))
+            raise SerialException('expected a string in the form "socket://<host>:<port>[?logging={{debug|info|warning|error}}]": not starting with socket:// ({0!r})'.format(parts.scheme))
         try:
             # process options now, directly altering self
             for option, values in urlparse.parse_qs(parts.query, True).items():
@@ -113,13 +113,13 @@ class Serial(SerialBase):
                     self.logger.setLevel(LOGGER_LEVELS[values[0]])
                     self.logger.debug('enabled logging')
                 else:
-                    raise ValueError('unknown option: %r' % (option,))
+                    raise ValueError('unknown option: {0!r}'.format(option))
             # get host and port
             host, port = parts.hostname, parts.port
             if not 0 <= port < 65536:
                 raise ValueError("port not in range 0...65535")
         except ValueError as e:
-            raise SerialException('expected a string in the form "socket://<host>:<port>[?logging={debug|info|warning|error}]": %s' % e)
+            raise SerialException('expected a string in the form "socket://<host>:<port>[?logging={{debug|info|warning|error}}]": {0!s}'.format(e))
         return (host, port)
 
     #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
@@ -172,18 +172,18 @@ class Serial(SerialBase):
                 pass
             except socket.error as e:
                 # connection fails -> terminate loop
-                raise SerialException('connection failed (%s)' % e)
+                raise SerialException('connection failed ({0!s})'.format(e))
             except OSError as e:
                 # this is for Python 3.x where select.error is a subclass of
                 # OSError ignore EAGAIN errors. all other errors are shown
                 if e.errno != errno.EAGAIN:
-                    raise SerialException('read failed: %s' % (e,))
+                    raise SerialException('read failed: {0!s}'.format(e))
             except select.error as e:
                 # this is for Python 2.x
                 # ignore EAGAIN errors. all other errors are shown
                 # see also http://www.python.org/dev/peps/pep-3151/#select
                 if e[0] != errno.EAGAIN:
-                    raise SerialException('read failed: %s' % (e,))
+                    raise SerialException('read failed: {0!s}'.format(e))
         return bytes(read)
 
     def write(self, data):
@@ -198,7 +198,7 @@ class Serial(SerialBase):
             self._socket.sendall(to_bytes(data))
         except socket.error as e:
             # XXX what exception if socket connection fails
-            raise SerialException("socket connection failed: %s" % e)
+            raise SerialException("socket connection failed: {0!s}".format(e))
         return len(data)
 
     def reset_input_buffer(self):
@@ -226,23 +226,23 @@ class Serial(SerialBase):
         if not self.is_open:
             raise portNotOpenError
         if self.logger:
-            self.logger.info('ignored send_break(%r)' % (duration,))
+            self.logger.info('ignored send_break({0!r})'.format(duration))
 
     def _update_break_state(self):
         """Set break: Controls TXD. When active, to transmitting is
         possible."""
         if self.logger:
-            self.logger.info('ignored _update_break_state(%r)' % (self._break_state,))
+            self.logger.info('ignored _update_break_state({0!r})'.format(self._break_state))
 
     def _update_rts_state(self):
         """Set terminal status line: Request To Send"""
         if self.logger:
-            self.logger.info('ignored _update_rts_state(%r)' % (self._rts_state,))
+            self.logger.info('ignored _update_rts_state({0!r})'.format(self._rts_state))
 
     def _update_dtr_state(self):
         """Set terminal status line: Data Terminal Ready"""
         if self.logger:
-            self.logger.info('ignored _update_dtr_state(%r)' % (self._dtr_state,))
+            self.logger.info('ignored _update_dtr_state({0!r})'.format(self._dtr_state))
 
     @property
     def cts(self):
@@ -293,11 +293,11 @@ class Serial(SerialBase):
 if __name__ == '__main__':
     import sys
     s = Serial('socket://localhost:7000')
-    sys.stdout.write('%s\n' % s)
+    sys.stdout.write('{0!s}\n'.format(s))
 
     sys.stdout.write("write...\n")
     s.write(b"hello\n")
     s.flush()
-    sys.stdout.write("read: %s\n" % s.read(5))
+    sys.stdout.write("read: {0!s}\n".format(s.read(5)))
 
     s.close()

--- a/serial/urlhandler/protocol_spy.py
+++ b/serial/urlhandler/protocol_spy.py
@@ -162,7 +162,7 @@ class Serial(serial.Serial):
         """extract host and port from an URL string"""
         parts = urlparse.urlsplit(url)
         if parts.scheme != 'spy':
-            raise serial.SerialException('expected a string in the form "spy://port[?option[=value][&option[=value]]]": not starting with spy:// (%r)' % (parts.scheme,))
+            raise serial.SerialException('expected a string in the form "spy://port[?option[=value][&option[=value]]]": not starting with spy:// ({0!r})'.format(parts.scheme))
         # process options now, directly altering self
         formatter = FormatHexdump
         color = False
@@ -178,9 +178,9 @@ class Serial(serial.Serial):
                 elif option == 'all':
                     self.show_all = True
                 else:
-                    raise ValueError('unknown option: %r' % (option,))
+                    raise ValueError('unknown option: {0!r}'.format(option))
         except ValueError as e:
-            raise serial.SerialException('expected a string in the form "spy://port[?option[=value][&option[=value]]]": %s' % e)
+            raise serial.SerialException('expected a string in the form "spy://port[?option[=value][&option[=value]]]": {0!s}'.format(e))
         self.formatter = formatter(output, color)
         return ''.join([parts.netloc, parts.path])
 

--- a/test/handlers/protocol_test.py
+++ b/test/handlers/protocol_test.py
@@ -71,9 +71,9 @@ class DummySerial(SerialBase):
                         self.logger.setLevel(LOGGER_LEVELS[value])
                         self.logger.debug('enabled logging')
                     else:
-                        raise ValueError('unknown option: %r' % (option,))
+                        raise ValueError('unknown option: {0!r}'.format(option))
         except ValueError as e:
-            raise SerialException('expected a string in the form "[test://][option[/option...]]": %s' % e)
+            raise SerialException('expected a string in the form "[test://][option[/option...]]": {0!s}'.format(e))
         return (host, port)
 
     #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
@@ -120,26 +120,26 @@ class DummySerial(SerialBase):
         duration."""
         if not self._isOpen: raise portNotOpenError
         if self.logger:
-            self.logger.info('ignored sendBreak(%r)' % (duration,))
+            self.logger.info('ignored sendBreak({0!r})'.format(duration))
 
     def setBreak(self, level=True):
         """Set break: Controls TXD. When active, to transmitting is
         possible."""
         if not self._isOpen: raise portNotOpenError
         if self.logger:
-            self.logger.info('ignored setBreak(%r)' % (level,))
+            self.logger.info('ignored setBreak({0!r})'.format(level))
 
     def setRTS(self, level=True):
         """Set terminal status line: Request To Send"""
         if not self._isOpen: raise portNotOpenError
         if self.logger:
-            self.logger.info('ignored setRTS(%r)' % (level,))
+            self.logger.info('ignored setRTS({0!r})'.format(level))
 
     def setDTR(self, level=True):
         """Set terminal status line: Data Terminal Ready"""
         if not self._isOpen: raise portNotOpenError
         if self.logger:
-            self.logger.info('ignored setDTR(%r)' % (level,))
+            self.logger.info('ignored setDTR({0!r})'.format(level))
 
     def getCTS(self):
         """Read terminal status line: Clear To Send"""
@@ -192,11 +192,11 @@ else:
 if __name__ == '__main__':
     import sys
     s = Serial('test://logging=debug')
-    sys.stdout.write('%s\n' % s)
+    sys.stdout.write('{0!s}\n'.format(s))
 
     sys.stdout.write("write...\n")
     s.write("hello\n")
     s.flush()
-    sys.stdout.write("read: %s\n" % s.read(5))
+    sys.stdout.write("read: {0!s}\n".format(s.read(5)))
 
     s.close()

--- a/test/run_all_tests.py
+++ b/test/run_all_tests.py
@@ -18,7 +18,7 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import serial
-print("Patching sys.path to test local version. Testing Version: %s" % (serial.VERSION,))
+print("Patching sys.path to test local version. Testing Version: {0!s}".format(serial.VERSION))
 
 PORT = 'loop://'
 if len(sys.argv) > 1:
@@ -34,11 +34,11 @@ for modulename in [
     try:
         module = __import__(modulename)
     except ImportError:
-        print("skipping %s" % (modulename,))
+        print("skipping {0!s}".format(modulename))
     else:
         module.PORT = PORT
         testsuite = unittest.findTestCases(module)
-        print("found %s tests in %r" % (testsuite.countTestCases(), modulename))
+        print("found {0!s} tests in {1!r}".format(testsuite.countTestCases(), modulename))
         mainsuite.addTest(testsuite)
 
 verbosity = 1

--- a/test/test.py
+++ b/test/test.py
@@ -66,7 +66,7 @@ class Test4_Nonblocking(unittest.TestCase):
             self.s.write(block)
             # there might be a small delay until the character is ready (especially on win32)
             time.sleep(0.05)
-            self.assertEqual(self.s.in_waiting, length, "expected exactly %d character for inWainting()" % length)
+            self.assertEqual(self.s.in_waiting, length, "expected exactly {0:d} character for inWainting()".format(length))
             self.assertEqual(self.s.read(length), block)  #, "expected a %r which was written before" % block)
         self.assertEqual(self.s.read(1), b'', "expected empty buffer after all sent chars are read")
 
@@ -131,7 +131,7 @@ class Test1_Forever(unittest.TestCase):
         a character is sent after some time to terminate the test (SendEvent)."""
         c = self.s.read(1)
         if not (self.event.isSet() and c == b'E'):
-            self.fail("expected marker (evt=%r, c=%r)" % (self.event.isSet(), c))
+            self.fail("expected marker (evt={0!r}, c={1!r})".format(self.event.isSet(), c))
 
 
 class Test2_Forever(unittest.TestCase):
@@ -218,14 +218,14 @@ class Test_MoreTimeouts(unittest.TestCase):
         t1 = time.time()
         self.assertRaises(serial.SerialTimeoutException, self.s.write, b"timeout please" * 200)
         t2 = time.time()
-        self.assertTrue(0.9 <= (t2 - t1) < 2.1, "Timeout not in the given interval (%s)" % (t2 - t1))
+        self.assertTrue(0.9 <= (t2 - t1) < 2.1, "Timeout not in the given interval ({0!s})".format((t2 - t1)))
 
 
 if __name__ == '__main__':
     sys.stdout.write(__doc__)
     if len(sys.argv) > 1:
         PORT = sys.argv[1]
-    sys.stdout.write("Testing port: %r\n" % PORT)
+    sys.stdout.write("Testing port: {0!r}\n".format(PORT))
     sys.argv[1:] = ['-v']
     # When this module is executed from the command-line, it runs all its tests
     unittest.main()

--- a/test/test_advanced.py
+++ b/test/test_advanced.py
@@ -179,7 +179,7 @@ if __name__ == '__main__':
     sys.stdout.write(__doc__)
     if len(sys.argv) > 1:
         PORT = sys.argv[1]
-    sys.stdout.write("Testing port: %r\n" % PORT)
+    sys.stdout.write("Testing port: {0!r}\n".format(PORT))
     sys.argv[1:] = ['-v']
     # When this module is executed from the command-line, it runs all its tests
     unittest.main()

--- a/test/test_high_load.py
+++ b/test/test_high_load.py
@@ -61,7 +61,7 @@ class TestHighLoad(unittest.TestCase):
         for i in range(self.N):
             self.s.write(q)
         read = self.s.read(len(q) * self.N)
-        self.assertEqual(read, q * self.N, "expected what was written before. got %d bytes, expected %d" % (len(read), self.N * len(q)))
+        self.assertEqual(read, q * self.N, "expected what was written before. got {0:d} bytes, expected {1:d}".format(len(read), self.N * len(q)))
         self.assertEqual(self.s.inWaiting(), 0)  # "expected empty buffer after all sent chars are read")
 
 
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     sys.stdout.write(__doc__)
     if len(sys.argv) > 1:
         PORT = sys.argv[1]
-    sys.stdout.write("Testing port: %r\n" % PORT)
+    sys.stdout.write("Testing port: {0!r}\n".format(PORT))
     sys.argv[1:] = ['-v']
     # When this module is executed from the command-line, it runs all its tests
     unittest.main()

--- a/test/test_iolib.py
+++ b/test/test_iolib.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
     sys.stdout.write(__doc__)
     if len(sys.argv) > 1:
         PORT = sys.argv[1]
-    sys.stdout.write("Testing port: %r\n" % PORT)
+    sys.stdout.write("Testing port: {0!r}\n".format(PORT))
     sys.argv[1:] = ['-v']
     # When this module is executed from the command-line, it runs all its tests
     unittest.main()

--- a/test/test_readline.py
+++ b/test/test_readline.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     sys.stdout.write(__doc__)
     if len(sys.argv) > 1:
         PORT = sys.argv[1]
-    sys.stdout.write("Testing port: %r\n" % PORT)
+    sys.stdout.write("Testing port: {0!r}\n".format(PORT))
     sys.argv[1:] = ['-v']
     # When this module is executed from the command-line, it runs all its tests
     unittest.main()

--- a/test/test_rs485.py
+++ b/test/test_rs485.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     sys.stdout.write(__doc__)
     if len(sys.argv) > 1:
         PORT = sys.argv[1]
-    sys.stdout.write("Testing port: %r\n" % PORT)
+    sys.stdout.write("Testing port: {0!r}\n".format(PORT))
     sys.argv[1:] = ['-v']
     # When this module is executed from the command-line, it runs all its tests
     unittest.main()

--- a/test/test_settings_dict.py
+++ b/test/test_settings_dict.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
     sys.stdout.write(__doc__)
     if len(sys.argv) > 1:
         PORT = sys.argv[1]
-    sys.stdout.write("Testing port: %r\n" % PORT)
+    sys.stdout.write("Testing port: {0!r}\n".format(PORT))
     sys.argv[1:] = ['-v']
     # When this module is executed from the command-line, it runs all its tests
     unittest.main()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyserial?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pyserial?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
